### PR TITLE
add AVX benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,20 @@ ifdef WINDIR
 	CC = gcc
 endif
 
-tinymembench: main.c util.o util.h asm-opt.h version.h asm-opt.o x86-sse2.o arm-neon.o mips-32.o aarch64-asm.o
-	${CC} -O2 ${CFLAGS} -o tinymembench main.c util.o asm-opt.o x86-sse2.o arm-neon.o mips-32.o aarch64-asm.o -lm
+tinymembench: main.c util.o util.h asm-opt.h version.h asm-opt.o x86-sse2.o x86-avx2.o arm-neon.o mips-32.o aarch64-asm.o
+	${CC} -O2 ${CFLAGS} -o tinymembench main.c util.o asm-opt.o x86-sse2.o x86-avx2.o arm-neon.o mips-32.o aarch64-asm.o -lm
 
 util.o: util.c util.h
 	${CC} -O2 ${CFLAGS} -c util.c
 
-asm-opt.o: asm-opt.c asm-opt.h x86-sse2.h arm-neon.h mips-32.h
+asm-opt.o: asm-opt.c asm-opt.h x86-sse2.h x86-avx2.h arm-neon.h mips-32.h
 	${CC} -O2 ${CFLAGS} -c asm-opt.c
 
 x86-sse2.o: x86-sse2.S
 	${CC} -O2 ${CFLAGS} -c x86-sse2.S
+
+x86-avx2.o: x86-avx2.S
+	${CC} -O2 ${CFLAGS} -c x86-avx2.S
 
 arm-neon.o: arm-neon.S
 	${CC} -O2 ${CFLAGS} -c arm-neon.S

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifdef WINDIR
 endif
 
 tinymembench: main.c util.o util.h asm-opt.h version.h asm-opt.o x86-sse2.o x86-avx2.o x86-avx512.o arm-neon.o mips-32.o aarch64-asm.o
-	${CC} -O2 ${CFLAGS} -o tinymembench main.c util.o asm-opt.o x86-sse2.o x86-avx2.o arm-neon.o mips-32.o aarch64-asm.o -lm
+	${CC} -O2 ${CFLAGS} -o tinymembench main.c util.o asm-opt.o x86-sse2.o x86-avx2.o x86-avx512.o arm-neon.o mips-32.o aarch64-asm.o -lm
 
 util.o: util.c util.h
 	${CC} -O2 ${CFLAGS} -c util.c

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef WINDIR
 	CC = gcc
 endif
 
-tinymembench: main.c util.o util.h asm-opt.h version.h asm-opt.o x86-sse2.o x86-avx2.o arm-neon.o mips-32.o aarch64-asm.o
+tinymembench: main.c util.o util.h asm-opt.h version.h asm-opt.o x86-sse2.o x86-avx2.o x86-avx512.o arm-neon.o mips-32.o aarch64-asm.o
 	${CC} -O2 ${CFLAGS} -o tinymembench main.c util.o asm-opt.o x86-sse2.o x86-avx2.o arm-neon.o mips-32.o aarch64-asm.o -lm
 
 util.o: util.c util.h
@@ -18,6 +18,9 @@ x86-sse2.o: x86-sse2.S
 
 x86-avx2.o: x86-avx2.S
 	${CC} -O2 ${CFLAGS} -c x86-avx2.S
+
+x86-avx512.o: x86-avx512.S
+	${CC} -O2 ${CFLAGS} -c x86-avx512.S
 
 arm-neon.o: arm-neon.S
 	${CC} -O2 ${CFLAGS} -c arm-neon.S

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -186,9 +186,48 @@ static int check_sse2_support(void)
 #endif
 }
 
+#include "x86-avx2.h"
+
+static bench_info x86_avx2[] =
+{
+    { "AVX2 copy", 0, aligned_block_copy_avx2 },
+    { "AVX2 nontemporal copy", 0, aligned_block_copy_nt_avx2 },
+    { "AVX2 copy prefetched (32 bytes step)", 0, aligned_block_copy_pf32_avx2 },
+    { "AVX2 copy prefetched (64 bytes step)", 0, aligned_block_copy_pf64_avx2 },
+    { "AVX2 nontemporal copy prefetched (32 bytes step)", 0, aligned_block_copy_nt_pf32_avx2 },
+    { "AVX2 nontemporal copy prefetched (64 bytes step)", 0, aligned_block_copy_nt_pf64_avx2 },
+    { "AVX2 2-pass copy", 1, aligned_block_copy_avx2 },
+    { "AVX2 2-pass copy prefetched (32 bytes step)", 1, aligned_block_copy_pf32_avx2 },
+    { "AVX2 2-pass copy prefetched (64 bytes step)", 1, aligned_block_copy_pf64_avx2 },
+    { "AVX2 2-pass nontemporal copy", 1, aligned_block_copy_nt_avx2 },
+    { "AVX2 fill", 0, aligned_block_fill_avx2 },
+    { "AVX2 nontemporal fill", 0, aligned_block_fill_nt_avx2 },
+    { NULL, 0, NULL }
+};
+
+static bench_info x86_avx2_fb[] =
+{
+    { "AVX2 copy (from framebuffer)", 0, aligned_block_copy_avx2 },
+    { "AVX2 2-pass copy (from framebuffer)", 1, aligned_block_copy_avx2 },
+    { NULL, 0, NULL }
+};
+
+static int check_avx2_support(void)
+{
+#ifdef __amd64__
+    /* FIXME - need a real check for AVX2 support */
+    return 1; /* We assume that all 64-bit processors have AVX2 support */
+#else
+    return 0;
+#endif
+}
+
 bench_info *get_asm_benchmarks(void)
 {
-    if (check_sse2_support())
+    /* FIXME - AVX2 should include SSE2 benchmarks */
+    if (check_avx2_support())
+        return x86_avx2;
+    else if (check_sse2_support())
         return x86_sse2;
     else
         return empty;
@@ -196,7 +235,10 @@ bench_info *get_asm_benchmarks(void)
 
 bench_info *get_asm_framebuffer_benchmarks(void)
 {
-    if (check_sse2_support())
+    /* FIXME - AVX2 should include SSE2 benchmarks */
+    if (check_avx2_support())
+        return x86_avx2_fb;
+    else if (check_sse2_support())
         return x86_sse2_fb;
     else
         return empty;

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -201,8 +201,7 @@ static bench_info x86_avx2[] =
     { "AVX2 2-pass copy prefetched (64 bytes step)", 1, aligned_block_copy_pf64_avx2 },
     { "AVX2 2-pass nontemporal copy", 1, aligned_block_copy_nt_avx2 },
     { "AVX2 fill", 0, aligned_block_fill_avx2 },
-    { "AVX2 nontemporal fill", 0, aligned_block_fill_nt_avx2 },
-    { NULL, 0, NULL }
+    { "AVX2 nontemporal fill", 0, aligned_block_fill_nt_avx2 }
 };
 
 static bench_info x86_avx2_fb[] =
@@ -224,13 +223,19 @@ static int check_avx2_support(void)
 
 bench_info *get_asm_benchmarks(void)
 {
-    /* FIXME - AVX2 should include SSE2 benchmarks */
-    if (check_avx2_support())
-        return x86_avx2;
-    else if (check_sse2_support())
+    if (check_avx2_support()) {
+        /* AVX2 should run AVX2 and SSE2 benchmakrs */
+        int len_avx2 = sizeof(x86_avx2)/sizeof(bench_info);
+        int len_sse2 = sizeof(x86_sse2)/sizeof(bench_info);
+        bench_info *x86_all = malloc((len_avx2+len_sse2)*sizeof(bench_info));
+        memcpy(x86_all, x86_avx2, len_avx2*sizeof(bench_info));
+        memcpy(x86_all+len_avx2, x86_sse2, len_sse2*sizeof(bench_info));
+        return x86_all;
+    } else if (check_sse2_support()) {
         return x86_sse2;
-    else
+    } else {
         return empty;
+    }
 }
 
 bench_info *get_asm_framebuffer_benchmarks(void)

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -222,6 +222,42 @@ static int check_avx2_support(void)
 #endif
 }
 
+#include "x86-avx512.h"
+
+static bench_info x86_avx512[] =
+{
+    { "AVX512 copy", 0, aligned_block_copy_avx512 },
+    { "AVX512 nontemporal copy", 0, aligned_block_copy_nt_avx512 },
+    { "AVX512 copy prefetched (32 bytes step)", 0, aligned_block_copy_pf32_avx512 },
+    { "AVX512 copy prefetched (64 bytes step)", 0, aligned_block_copy_pf64_avx512 },
+    { "AVX512 nontemporal copy prefetched (32 bytes step)", 0, aligned_block_copy_nt_pf32_avx512 },
+    { "AVX512 nontemporal copy prefetched (64 bytes step)", 0, aligned_block_copy_nt_pf64_avx512 },
+    { "AVX512 2-pass copy", 1, aligned_block_copy_avx512 },
+    { "AVX512 2-pass copy prefetched (32 bytes step)", 1, aligned_block_copy_pf32_avx512 },
+    { "AVX512 2-pass copy prefetched (64 bytes step)", 1, aligned_block_copy_pf64_avx512 },
+    { "AVX512 2-pass nontemporal copy", 1, aligned_block_copy_nt_avx512 },
+    { "AVX512 fill", 0, aligned_block_fill_avx512 },
+    { "AVX512 nontemporal fill", 0, aligned_block_fill_nt_avx512 },
+    { NULL, 0, NULL }
+};
+
+static bench_info x86_avx512_fb[] =
+{
+    { "AVX512 copy (from framebuffer)", 0, aligned_block_copy_avx512 },
+    { "AVX512 2-pass copy (from framebuffer)", 1, aligned_block_copy_avx512 },
+    { NULL, 0, NULL }
+};
+
+static int check_avx512_support(void)
+{
+#ifdef __amd64__
+    /* FIXME - need a real check for AVX512 support */
+    return 1; /* We assume that all 64-bit processors have AVX512 support */
+#else
+    return 0;
+#endif
+}
+
 bench_info *get_asm_benchmarks(void)
 {
     if (check_sse2_support()) {
@@ -252,6 +288,23 @@ bench_info *get_avx2_framebuffer_benchmarks(void)
 {
     if (check_avx2_support())
         return x86_avx2_fb;
+    else
+        return empty;
+}
+
+bench_info *get_avx512_benchmarks(void)
+{
+    if (check_avx512_support()) {
+        return x86_avx512;
+    } else {
+        return empty;
+    }
+}
+
+bench_info *get_avx512_framebuffer_benchmarks(void)
+{
+    if (check_avx512_support())
+        return x86_avx512_fb;
     else
         return empty;
 }

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -201,7 +201,8 @@ static bench_info x86_avx2[] =
     { "AVX2 2-pass copy prefetched (64 bytes step)", 1, aligned_block_copy_pf64_avx2 },
     { "AVX2 2-pass nontemporal copy", 1, aligned_block_copy_nt_avx2 },
     { "AVX2 fill", 0, aligned_block_fill_avx2 },
-    { "AVX2 nontemporal fill", 0, aligned_block_fill_nt_avx2 }
+    { "AVX2 nontemporal fill", 0, aligned_block_fill_nt_avx2 },
+    { NULL, 0, NULL }
 };
 
 static bench_info x86_avx2_fb[] =
@@ -223,14 +224,7 @@ static int check_avx2_support(void)
 
 bench_info *get_asm_benchmarks(void)
 {
-    if (check_avx2_support()) {
-        /* AVX2 should run AVX2 and SSE2 benchmakrs */
-        int len_avx2 = sizeof(x86_avx2)/sizeof(bench_info);
-        bench_info *x86_all = malloc(sizeof(x86_avx2)+sizeof(x86_sse2));
-        memcpy(x86_all, x86_avx2, sizeof(x86_avx2));
-        memcpy(x86_all+len_avx2, x86_sse2, sizeof(x86_sse2));
-        return x86_all;
-    } else if (check_sse2_support()) {
+    if (check_sse2_support()) {
         return x86_sse2;
     } else {
         return empty;
@@ -239,11 +233,25 @@ bench_info *get_asm_benchmarks(void)
 
 bench_info *get_asm_framebuffer_benchmarks(void)
 {
-    /* FIXME - AVX2 should include SSE2 benchmarks */
+    if (check_sse2_support())
+        return x86_sse2_fb;
+    else
+        return empty;
+}
+
+bench_info *get_avx2_benchmarks(void)
+{
+    if (check_avx2_support()) {
+        return x86_avx2;
+    } else {
+        return empty;
+    }
+}
+
+bench_info *get_avx2_framebuffer_benchmarks(void)
+{
     if (check_avx2_support())
         return x86_avx2_fb;
-    else if (check_sse2_support())
-        return x86_sse2_fb;
     else
         return empty;
 }

--- a/asm-opt.c
+++ b/asm-opt.c
@@ -226,10 +226,9 @@ bench_info *get_asm_benchmarks(void)
     if (check_avx2_support()) {
         /* AVX2 should run AVX2 and SSE2 benchmakrs */
         int len_avx2 = sizeof(x86_avx2)/sizeof(bench_info);
-        int len_sse2 = sizeof(x86_sse2)/sizeof(bench_info);
-        bench_info *x86_all = malloc((len_avx2+len_sse2)*sizeof(bench_info));
-        memcpy(x86_all, x86_avx2, len_avx2*sizeof(bench_info));
-        memcpy(x86_all+len_avx2, x86_sse2, len_sse2*sizeof(bench_info));
+        bench_info *x86_all = malloc(sizeof(x86_avx2)+sizeof(x86_sse2));
+        memcpy(x86_all, x86_avx2, sizeof(x86_avx2));
+        memcpy(x86_all+len_avx2, x86_sse2, sizeof(x86_sse2));
         return x86_all;
     } else if (check_sse2_support()) {
         return x86_sse2;

--- a/asm-opt.h
+++ b/asm-opt.h
@@ -37,5 +37,7 @@ bench_info *get_asm_benchmarks(void);
 bench_info *get_asm_framebuffer_benchmarks(void);
 bench_info *get_avx2_benchmarks(void);
 bench_info *get_avx2_framebuffer_benchmarks(void);
+bench_info *get_avx512_benchmarks(void);
+bench_info *get_avx512_framebuffer_benchmarks(void);
 
 #endif

--- a/asm-opt.h
+++ b/asm-opt.h
@@ -35,5 +35,7 @@ typedef struct
 
 bench_info *get_asm_benchmarks(void);
 bench_info *get_asm_framebuffer_benchmarks(void);
+bench_info *get_avx2_benchmarks(void);
+bench_info *get_avx2_framebuffer_benchmarks(void);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -563,6 +563,11 @@ int main(int argc, char *argv[])
         printf(" ---\n");
         bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi);
     }
+    bench_info *bi_avx2 = get_avx2_benchmarks();
+    if (bi_avx2->f) {
+        printf(" ---\n");
+        bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx2);
+    }
 
 #ifdef __linux__
     bi = get_asm_framebuffer_benchmarks();
@@ -594,6 +599,7 @@ int main(int argc, char *argv[])
             bufsize = fbsize;
         bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi);
     }
+    /* TODO: add get_avx2_framebuffer_benchmarks */
 #endif
 
     free(poolbuf);

--- a/main.c
+++ b/main.c
@@ -568,6 +568,11 @@ int main(int argc, char *argv[])
         printf(" ---\n");
         bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx2);
     }
+    bench_info *bi_avx512 = get_avx512_benchmarks();
+    if (bi_avx512->f) {
+        printf(" ---\n");
+        bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx512);
+    }
 
 #ifdef __linux__
     bi = get_asm_framebuffer_benchmarks();
@@ -599,7 +604,7 @@ int main(int argc, char *argv[])
             bufsize = fbsize;
         bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi);
     }
-    /* TODO: add get_avx2_framebuffer_benchmarks */
+    /* TODO: add get_avx2_framebuffer_benchmarks and get_avx512_framebuffer_benchmarks */
 #endif
 
     free(poolbuf);

--- a/main.c
+++ b/main.c
@@ -21,6 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#include <getopt.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -493,35 +494,62 @@ usage()
 	fprintf(stderr, "\t-s Memory buffer size in Bytes <%d>\n", SIZE);
 	fprintf(stderr, "\t-l Latency test maximum buffer size in Bytes <%d>\n", SIZE * 2);
 	fprintf(stderr, "\t-c Latency count <%d>\n", LATBENCH_COUNT);
+    fprintf(stderr, "\t--run_sse Include SSE2 tests <false>\n");
+    fprintf(stderr, "\t--run_sse Include AVX2 tests <false>\n");
+    fprintf(stderr, "\t--run_sse Include AVX512 tests <false>\n");
 	exit(EXIT_FAILURE);
 }
 
+
 int main(int argc, char *argv[])
 {
-	int ch;
-	int latbench_size = SIZE * 2, latbench_count = LATBENCH_COUNT;
+	int c, latbench_size = SIZE * 2, latbench_count = LATBENCH_COUNT;
 	size_t bufsize = SIZE;
 	int blocksize = BLOCKSIZE;
+    static int run_sse2 = 0;
+    static int run_avx2 = 0;
+    static int run_avx512 = 0;
 	
 	progname = argv[0];
-	while ((ch = getopt(argc, argv, "hb:c:l:s:")) != -1) {
-		switch (ch) {
-		case 'b':
-		    blocksize = atoi(optarg);
-			break;
-		case 'c':
-		    latbench_count = atoi(optarg);
-			break;
-		case 'l':
-		    latbench_size = atoi(optarg);
-			break;
-		case 's':
-		    bufsize = atoi(optarg);
-			break;
-		case 'h':
-		    usage();
-		}
-	}
+    while (1) {
+        static struct option long_options[] = {
+            {"run_sse2", no_argument, &run_sse2, 1},
+            {"run_avx2", no_argument, &run_avx2, 1},
+            {"run_avx512", no_argument, &run_avx512, 1},
+            {0, 0, 0, 0}
+        };
+        /* getopt_long stores the option index here. */
+        int option_index = 0;
+        c = getopt_long(argc, argv, "hb:c:l:s:", long_options, &option_index);
+        if (c == -1)
+            break;
+		switch (c) {
+            case 0:
+                if (long_options[option_index].flag != 0)
+                    break;
+                printf ("option %s", long_options[option_index].name);
+                if (optarg)
+                    printf (" with arg %s", optarg);
+                printf ("\n");
+                break;
+		    case 'b':
+		        blocksize = atoi(optarg);
+			    break;
+		    case 'c':
+		        latbench_count = atoi(optarg);
+			    break;
+		    case 'l':
+		        latbench_size = atoi(optarg);
+			    break;
+		    case 's':
+		        bufsize = atoi(optarg);
+			    break;
+		    case 'h':
+		        usage();
+            default:
+                abort();
+	    }
+    }
 
     int64_t *srcbuf, *dstbuf, *tmpbuf;
     void *poolbuf;
@@ -558,24 +586,30 @@ int main(int argc, char *argv[])
     bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", c_benchmarks);
     printf(" ---\n");
     bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", libc_benchmarks);
-    bench_info *bi = get_asm_benchmarks();
-    if (bi->f) {
-        printf(" ---\n");
-        bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi);
+    if (run_sse2) {
+        bench_info *bi = get_asm_benchmarks();
+        if (bi->f) {
+            printf(" ---\n");
+            bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi);
+        }
     }
-    bench_info *bi_avx2 = get_avx2_benchmarks();
-    if (bi_avx2->f) {
-        printf(" ---\n");
-        bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx2);
+    if (run_avx2) {
+        bench_info *bi_avx2 = get_avx2_benchmarks();
+        if (bi_avx2->f) {
+            printf(" ---\n");
+            bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx2);
+        }
     }
-    bench_info *bi_avx512 = get_avx512_benchmarks();
-    if (bi_avx512->f) {
-        printf(" ---\n");
-        bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx512);
+    if (run_avx512) {
+        bench_info *bi_avx512 = get_avx512_benchmarks();
+        if (bi_avx512->f) {
+            printf(" ---\n");
+            bandwidth_bench(dstbuf, srcbuf, tmpbuf, bufsize, blocksize, " ", bi_avx512);
+        }
     }
 
 #ifdef __linux__
-    bi = get_asm_framebuffer_benchmarks();
+    bench_info *bi = get_asm_framebuffer_benchmarks();
     if (bi->f && fbbuf)
     {
         printf("\n");

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if defined(__i386__) || defined(__amd64__)
+
+.intel_syntax noprefix
+.text
+
+#define PREFETCH_DISTANCE 256
+
+.macro asm_function_helper function_name
+    .global \function_name
+.func \function_name
+\function_name:
+#ifdef __amd64__
+  #ifdef _WIN64
+    .set DST,  rcx
+    .set SRC,  rdx
+    .set SIZE, r8
+  #else
+    .set DST,  rdi
+    .set SRC,  rsi
+    .set SIZE, rdx
+  #endif
+#else
+    mov  eax,  [esp + 4]
+    mov  ecx,  [esp + 8]
+    mov  edx,  [esp + 12]
+    .set DST,  eax
+    .set SRC,  ecx
+    .set SIZE, edx
+#endif
+.endm
+
+.macro asm_function function_name
+#if defined(_WIN32) && !defined(_WIN64)
+    asm_function_helper _\function_name
+#else
+    asm_function_helper \function_name
+#endif
+.endm
+
+.macro push3 a, b, c
+    push \a
+    push \b
+    push \c
+.endm
+
+.macro pop3 a, b, c
+    pop \c
+    pop \b
+    pop \a
+.endm
+
+/*****************************************************************************/
+
+asm_function aligned_block_copy_movsb
+0:
+#ifdef __amd64__
+    push3       rdi rsi rcx
+    push3       DST SRC SIZE
+    pop3        rdi rsi rcx
+    rep movsb
+    pop3        rdi rsi rcx
+#else
+    push3       edi esi ecx
+    push3       DST SRC SIZE
+    pop3        edi esi ecx
+    rep movsb
+    pop3        edi esi ecx
+#endif
+    ret
+.endfunc
+
+asm_function aligned_block_copy_movsd
+0:
+#ifdef __amd64__
+    push3       rdi rsi rcx
+    push3       DST SRC SIZE
+    pop3        rdi rsi rcx
+    sar         rcx, 2
+    rep movsd
+    pop3        rdi rsi rcx
+#else
+    push3       edi esi ecx
+    push3       DST SRC SIZE
+    pop3        edi esi ecx
+    sar         ecx, 2
+    rep movsd
+    pop3        edi esi ecx
+#endif
+    ret
+.endfunc
+
+asm_function aligned_block_copy_sse2
+0:
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movdqa      [DST + 0],  xmm0
+    movdqa      [DST + 16], xmm1
+    movdqa      [DST + 32], xmm2
+    movdqa      [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE, 64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_sse2
+0:
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movntdq     [DST + 0],  xmm0
+    movntdq     [DST + 16], xmm1
+    movntdq     [DST + 32], xmm2
+    movntdq     [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE, 64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_pf32_sse2
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    prefetchnta [SRC + PREFETCH_DISTANCE + 32]
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movdqa      [DST + 0],  xmm0
+    movdqa      [DST + 16], xmm1
+    movdqa      [DST + 32], xmm2
+    movdqa      [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_pf32_sse2
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    prefetchnta [SRC + PREFETCH_DISTANCE + 32]
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movntdq     [DST + 0],  xmm0
+    movntdq     [DST + 16], xmm1
+    movntdq     [DST + 32], xmm2
+    movntdq     [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_pf64_sse2
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movdqa      [DST + 0],  xmm0
+    movdqa      [DST + 16], xmm1
+    movdqa      [DST + 32], xmm2
+    movdqa      [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_pf64_sse2
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    movdqa      xmm0,       [SRC + 0]
+    movdqa      xmm1,       [SRC + 16]
+    movdqa      xmm2,       [SRC + 32]
+    movdqa      xmm3,       [SRC + 48]
+    movntdq     [DST + 0],  xmm0
+    movntdq     [DST + 16], xmm1
+    movntdq     [DST + 32], xmm2
+    movntdq     [DST + 48], xmm3
+    add         SRC,        64
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_fill_sse2
+    movdqa      xmm0,       [SRC + 0]
+0:
+    movdqa      [DST + 0],  xmm0
+    movdqa      [DST + 16], xmm0
+    movdqa      [DST + 32], xmm0
+    movdqa      [DST + 48], xmm0
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_fill_nt_sse2
+    movdqa      xmm0,       [SRC + 0]
+0:
+    movntdq     [DST + 0],  xmm0
+    movntdq     [DST + 16], xmm0
+    movntdq     [DST + 32], xmm0
+    movntdq     [DST + 48], xmm0
+    add         DST,        64
+    sub         SIZE,       64
+    jg          0b
+    ret
+.endfunc
+
+/*****************************************************************************/
+
+#endif

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -99,19 +99,19 @@ asm_function aligned_block_copy_avx2
     ret
 .endfunc
 
-asm_function aligned_block_copy_nt_sse2
+asm_function aligned_block_copy_nt_avx2
 0:
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movntdq     [DST + 0],  xmm0
-    movntdq     [DST + 16], xmm1
-    movntdq     [DST + 32], xmm2
-    movntdq     [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE, 64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovntdq     [DST + (0 * 32)], ymm0
+    vmovntdq     [DST + (1 * 32)], ymm1
+    vmovntdq     [DST + (2 * 32)], ymm2
+    vmovntdq     [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE, (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -61,27 +61,6 @@ asm_function_helper \function_name
 
 /*****************************************************************************/
 
-asm_function aligned_block_copy_movsb
-0:
-    push3       rdi rsi rcx
-    push3       DST SRC SIZE
-    pop3        rdi rsi rcx
-    rep movsb
-    pop3        rdi rsi rcx
-    ret
-.endfunc
-
-asm_function aligned_block_copy_movsd
-0:
-    push3       rdi rsi rcx
-    push3       DST SRC SIZE
-    pop3        rdi rsi rcx
-    sar         rcx, 2
-    rep movsd
-    pop3        rdi rsi rcx
-    ret
-.endfunc
-
 asm_function aligned_block_copy_avx2
 0:
     vmovdqa      ymm0,       [SRC + (0 * 32)]

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ * Copyright © 2020 Joel Luth <joelluth@gmail.com>
+ * Based on code by Siarhei Siamashka <siarhei.siamashka@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -28,6 +28,7 @@
 .text
 
 #define PREFETCH_DISTANCE 256
+#define REGSZ 32
 
 .macro asm_function_helper function_name
     .global \function_name
@@ -64,34 +65,34 @@ asm_function_helper \function_name
 
 asm_function aligned_block_copy_avx2
 0:
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovdqa      [DST + (0 * 32)], ymm0
-    vmovdqa      [DST + (1 * 32)], ymm1
-    vmovdqa      [DST + (2 * 32)], ymm2
-    vmovdqa      [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE, (4 * 32)
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], ymm0
+    vmovdqa      [DST + (1 * REGSZ)], ymm1
+    vmovdqa      [DST + (2 * REGSZ)], ymm2
+    vmovdqa      [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE, (4 * REGSZ)
     jg          0b
     ret
 .endfunc
 
 asm_function aligned_block_copy_nt_avx2
 0:
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovntdq     [DST + (0 * 32)], ymm0
-    vmovntdq     [DST + (1 * 32)], ymm1
-    vmovntdq     [DST + (2 * 32)], ymm2
-    vmovntdq     [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE, (4 * 32)
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], ymm0
+    vmovntdq     [DST + (1 * REGSZ)], ymm1
+    vmovntdq     [DST + (2 * REGSZ)], ymm2
+    vmovntdq     [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE, (4 * REGSZ)
     jg          0b
     ret
 .endfunc
@@ -99,18 +100,18 @@ asm_function aligned_block_copy_nt_avx2
 asm_function aligned_block_copy_pf32_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    prefetchnta [SRC + PREFETCH_DISTANCE + 32]
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovdqa      [DST + (0 * 32)], ymm0
-    vmovdqa      [DST + (1 * 32)], ymm1
-    vmovdqa      [DST + (2 * 32)], ymm2
-    vmovdqa      [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], ymm0
+    vmovdqa      [DST + (1 * REGSZ)], ymm1
+    vmovdqa      [DST + (2 * REGSZ)], ymm2
+    vmovdqa      [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc
@@ -118,18 +119,18 @@ asm_function aligned_block_copy_pf32_avx2
 asm_function aligned_block_copy_nt_pf32_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    prefetchnta [SRC + PREFETCH_DISTANCE + 32]
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovntdq     [DST + (0 * 32)], ymm0
-    vmovntdq     [DST + (1 * 32)], ymm1
-    vmovntdq     [DST + (2 * 32)], ymm2
-    vmovntdq     [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], ymm0
+    vmovntdq     [DST + (1 * REGSZ)], ymm1
+    vmovntdq     [DST + (2 * REGSZ)], ymm2
+    vmovntdq     [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc
@@ -137,17 +138,17 @@ asm_function aligned_block_copy_nt_pf32_avx2
 asm_function aligned_block_copy_pf64_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovdqa      [DST + (0 * 32)], ymm0
-    vmovdqa      [DST + (1 * 32)], ymm1
-    vmovdqa      [DST + (2 * 32)], ymm2
-    vmovdqa      [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], ymm0
+    vmovdqa      [DST + (1 * REGSZ)], ymm1
+    vmovdqa      [DST + (2 * REGSZ)], ymm2
+    vmovdqa      [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc
@@ -155,43 +156,43 @@ asm_function aligned_block_copy_pf64_avx2
 asm_function aligned_block_copy_nt_pf64_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
-    vmovdqa      ymm1,       [SRC + (1 * 32)]
-    vmovdqa      ymm2,       [SRC + (2 * 32)]
-    vmovdqa      ymm3,       [SRC + (3 * 32)]
-    vmovntdq     [DST + (0 * 32)], ymm0
-    vmovntdq     [DST + (1 * 32)], ymm1
-    vmovntdq     [DST + (2 * 32)], ymm2
-    vmovntdq     [DST + (3 * 32)], ymm3
-    add         SRC,        (4 * 32)
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      ymm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      ymm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      ymm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], ymm0
+    vmovntdq     [DST + (1 * REGSZ)], ymm1
+    vmovntdq     [DST + (2 * REGSZ)], ymm2
+    vmovntdq     [DST + (3 * REGSZ)], ymm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc
 
 asm_function aligned_block_fill_avx2
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
 0:
-    vmovdqa      [DST + (0 * 32)], ymm0
-    vmovdqa      [DST + (1 * 32)], ymm0
-    vmovdqa      [DST + (2 * 32)], ymm0
-    vmovdqa      [DST + (3 * 32)], ymm0
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    vmovdqa      [DST + (0 * REGSZ)], ymm0
+    vmovdqa      [DST + (1 * REGSZ)], ymm0
+    vmovdqa      [DST + (2 * REGSZ)], ymm0
+    vmovdqa      [DST + (3 * REGSZ)], ymm0
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc
 
 asm_function aligned_block_fill_nt_avx2
-    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm0,       [SRC + (0 * REGSZ)]
 0:
-    vmovntdq     [DST + (0 * 32)], ymm0
-    vmovntdq     [DST + (1 * 32)], ymm0
-    vmovntdq     [DST + (2 * 32)], ymm0
-    vmovntdq     [DST + (3 * 32)], ymm0
-    add         DST,        (4 * 32)
-    sub         SIZE,       (4 * 32)
+    vmovntdq     [DST + (0 * REGSZ)], ymm0
+    vmovntdq     [DST + (1 * REGSZ)], ymm0
+    vmovntdq     [DST + (2 * REGSZ)], ymm0
+    vmovntdq     [DST + (3 * REGSZ)], ymm0
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -116,21 +116,21 @@ asm_function aligned_block_copy_nt_avx2
     ret
 .endfunc
 
-asm_function aligned_block_copy_pf32_sse2
+asm_function aligned_block_copy_pf32_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
     prefetchnta [SRC + PREFETCH_DISTANCE + 32]
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movdqa      [DST + 0],  xmm0
-    movdqa      [DST + 16], xmm1
-    movdqa      [DST + 32], xmm2
-    movdqa      [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE,       64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovdqa      [DST + (0 * 32)], ymm0
+    vmovdqa      [DST + (1 * 32)], ymm1
+    vmovdqa      [DST + (2 * 32)], ymm2
+    vmovdqa      [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -190,15 +190,15 @@ asm_function aligned_block_copy_nt_pf64_avx2
     ret
 .endfunc
 
-asm_function aligned_block_fill_sse2
-    movdqa      xmm0,       [SRC + 0]
+asm_function aligned_block_fill_avx2
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
 0:
-    movdqa      [DST + 0],  xmm0
-    movdqa      [DST + 16], xmm0
-    movdqa      [DST + 32], xmm0
-    movdqa      [DST + 48], xmm0
-    add         DST,        64
-    sub         SIZE,       64
+    vmovdqa      [DST + (0 * 32)], ymm0
+    vmovdqa      [DST + (1 * 32)], ymm0
+    vmovdqa      [DST + (2 * 32)], ymm0
+    vmovdqa      [DST + (3 * 32)], ymm0
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -82,19 +82,19 @@ asm_function aligned_block_copy_movsd
     ret
 .endfunc
 
-asm_function aligned_block_copy_sse2
+asm_function aligned_block_copy_avx2
 0:
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movdqa      [DST + 0],  xmm0
-    movdqa      [DST + 16], xmm1
-    movdqa      [DST + 32], xmm2
-    movdqa      [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE, 64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovdqa      [DST + (0 * 32)], ymm0
+    vmovdqa      [DST + (1 * 32)], ymm1
+    vmovdqa      [DST + (2 * 32)], ymm2
+    vmovdqa      [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE, (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -21,7 +21,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#if defined(__i386__) || defined(__amd64__)
+#if defined(__amd64__)
 
 .intel_syntax noprefix
 .text
@@ -32,32 +32,19 @@
     .global \function_name
 .func \function_name
 \function_name:
-#ifdef __amd64__
-  #ifdef _WIN64
+#ifdef _WIN64
     .set DST,  rcx
     .set SRC,  rdx
     .set SIZE, r8
-  #else
+#else
     .set DST,  rdi
     .set SRC,  rsi
     .set SIZE, rdx
-  #endif
-#else
-    mov  eax,  [esp + 4]
-    mov  ecx,  [esp + 8]
-    mov  edx,  [esp + 12]
-    .set DST,  eax
-    .set SRC,  ecx
-    .set SIZE, edx
 #endif
 .endm
 
 .macro asm_function function_name
-#if defined(_WIN32) && !defined(_WIN64)
-    asm_function_helper _\function_name
-#else
-    asm_function_helper \function_name
-#endif
+asm_function_helper \function_name
 .endm
 
 .macro push3 a, b, c
@@ -76,39 +63,22 @@
 
 asm_function aligned_block_copy_movsb
 0:
-#ifdef __amd64__
     push3       rdi rsi rcx
     push3       DST SRC SIZE
     pop3        rdi rsi rcx
     rep movsb
     pop3        rdi rsi rcx
-#else
-    push3       edi esi ecx
-    push3       DST SRC SIZE
-    pop3        edi esi ecx
-    rep movsb
-    pop3        edi esi ecx
-#endif
     ret
 .endfunc
 
 asm_function aligned_block_copy_movsd
 0:
-#ifdef __amd64__
     push3       rdi rsi rcx
     push3       DST SRC SIZE
     pop3        rdi rsi rcx
     sar         rcx, 2
     rep movsd
     pop3        rdi rsi rcx
-#else
-    push3       edi esi ecx
-    push3       DST SRC SIZE
-    pop3        edi esi ecx
-    sar         ecx, 2
-    rep movsd
-    pop3        edi esi ecx
-#endif
     ret
 .endfunc
 

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -203,15 +203,15 @@ asm_function aligned_block_fill_avx2
     ret
 .endfunc
 
-asm_function aligned_block_fill_nt_sse2
-    movdqa      xmm0,       [SRC + 0]
+asm_function aligned_block_fill_nt_avx2
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
 0:
-    movntdq     [DST + 0],  xmm0
-    movntdq     [DST + 16], xmm0
-    movntdq     [DST + 32], xmm0
-    movntdq     [DST + 48], xmm0
-    add         DST,        64
-    sub         SIZE,       64
+    vmovntdq     [DST + (0 * 32)], ymm0
+    vmovntdq     [DST + (1 * 32)], ymm0
+    vmovntdq     [DST + (2 * 32)], ymm0
+    vmovntdq     [DST + (3 * 32)], ymm0
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -135,39 +135,39 @@ asm_function aligned_block_copy_pf32_avx2
     ret
 .endfunc
 
-asm_function aligned_block_copy_nt_pf32_sse2
+asm_function aligned_block_copy_nt_pf32_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
     prefetchnta [SRC + PREFETCH_DISTANCE + 32]
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movntdq     [DST + 0],  xmm0
-    movntdq     [DST + 16], xmm1
-    movntdq     [DST + 32], xmm2
-    movntdq     [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE,       64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovntdq     [DST + (0 * 32)], ymm0
+    vmovntdq     [DST + (1 * 32)], ymm1
+    vmovntdq     [DST + (2 * 32)], ymm2
+    vmovntdq     [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc
 
-asm_function aligned_block_copy_pf64_sse2
+asm_function aligned_block_copy_pf64_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movdqa      [DST + 0],  xmm0
-    movdqa      [DST + 16], xmm1
-    movdqa      [DST + 32], xmm2
-    movdqa      [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE,       64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovdqa      [DST + (0 * 32)], ymm0
+    vmovdqa      [DST + (1 * 32)], ymm1
+    vmovdqa      [DST + (2 * 32)], ymm2
+    vmovdqa      [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.S
+++ b/x86-avx2.S
@@ -172,20 +172,20 @@ asm_function aligned_block_copy_pf64_avx2
     ret
 .endfunc
 
-asm_function aligned_block_copy_nt_pf64_sse2
+asm_function aligned_block_copy_nt_pf64_avx2
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    movdqa      xmm0,       [SRC + 0]
-    movdqa      xmm1,       [SRC + 16]
-    movdqa      xmm2,       [SRC + 32]
-    movdqa      xmm3,       [SRC + 48]
-    movntdq     [DST + 0],  xmm0
-    movntdq     [DST + 16], xmm1
-    movntdq     [DST + 32], xmm2
-    movntdq     [DST + 48], xmm3
-    add         SRC,        64
-    add         DST,        64
-    sub         SIZE,       64
+    vmovdqa      ymm0,       [SRC + (0 * 32)]
+    vmovdqa      ymm1,       [SRC + (1 * 32)]
+    vmovdqa      ymm2,       [SRC + (2 * 32)]
+    vmovdqa      ymm3,       [SRC + (3 * 32)]
+    vmovntdq     [DST + (0 * 32)], ymm0
+    vmovntdq     [DST + (1 * 32)], ymm1
+    vmovntdq     [DST + (2 * 32)], ymm2
+    vmovntdq     [DST + (3 * 32)], ymm3
+    add         SRC,        (4 * 32)
+    add         DST,        (4 * 32)
+    sub         SIZE,       (4 * 32)
     jg          0b
     ret
 .endfunc

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __X86_SSE2_H__
+#define __X86_SSE2_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aligned_block_copy_movsb(int64_t * __restrict dst,
+                              int64_t * __restrict src,
+                              int                  size);
+void aligned_block_copy_movsd(int64_t * __restrict dst,
+                              int64_t * __restrict src,
+                              int                  size);
+
+void aligned_block_copy_sse2(int64_t * __restrict dst,
+                             int64_t * __restrict src,
+                             int                  size);
+void aligned_block_copy_nt_sse2(int64_t * __restrict dst,
+                                int64_t * __restrict src,
+                                int                  size);
+
+void aligned_block_copy_pf32_sse2(int64_t * __restrict dst,
+                                  int64_t * __restrict src,
+                                  int                  size);
+void aligned_block_copy_pf64_sse2(int64_t * __restrict dst,
+                                  int64_t * __restrict src,
+                                  int                  size);
+
+void aligned_block_copy_nt_pf32_sse2(int64_t * __restrict dst,
+                                     int64_t * __restrict src,
+                                     int                  size);
+void aligned_block_copy_nt_pf64_sse2(int64_t * __restrict dst,
+                                     int64_t * __restrict src,
+                                     int                  size);
+
+void aligned_block_fill_sse2(int64_t * __restrict dst,
+                             int64_t * __restrict src,
+                             int                  size);
+
+void aligned_block_fill_nt_sse2(int64_t * __restrict dst,
+                                int64_t * __restrict src,
+                                int                  size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -58,7 +58,7 @@ void aligned_block_copy_nt_pf64_avx2(int64_t * __restrict dst,
                                      int64_t * __restrict src,
                                      int                  size);
 
-void aligned_block_fill_sse2(int64_t * __restrict dst,
+void aligned_block_fill_avx2(int64_t * __restrict dst,
                              int64_t * __restrict src,
                              int                  size);
 

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -40,7 +40,7 @@ void aligned_block_copy_movsd(int64_t * __restrict dst,
 void aligned_block_copy_avx2(int64_t * __restrict dst,
                              int64_t * __restrict src,
                              int                  size);
-void aligned_block_copy_nt_sse2(int64_t * __restrict dst,
+void aligned_block_copy_nt_avx2(int64_t * __restrict dst,
                                 int64_t * __restrict src,
                                 int                  size);
 

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -21,8 +21,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __X86_SSE2_H__
-#define __X86_SSE2_H__
+#ifndef __X86_AVX2_H__
+#define __X86_AVX2_H__
 
 #include <stdint.h>
 

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -1,5 +1,6 @@
 /*
- * Copyright © 2011 Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ * Copyright © 2020 Joel Luth <joelluth@gmail.com>
+ * Based on code by Siarhei Siamashka <siarhei.siamashka@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -44,7 +44,7 @@ void aligned_block_copy_nt_avx2(int64_t * __restrict dst,
                                 int64_t * __restrict src,
                                 int                  size);
 
-void aligned_block_copy_pf32_sse2(int64_t * __restrict dst,
+void aligned_block_copy_pf32_avx2(int64_t * __restrict dst,
                                   int64_t * __restrict src,
                                   int                  size);
 void aligned_block_copy_pf64_sse2(int64_t * __restrict dst,

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -47,11 +47,11 @@ void aligned_block_copy_nt_avx2(int64_t * __restrict dst,
 void aligned_block_copy_pf32_avx2(int64_t * __restrict dst,
                                   int64_t * __restrict src,
                                   int                  size);
-void aligned_block_copy_pf64_sse2(int64_t * __restrict dst,
+void aligned_block_copy_pf64_avx2(int64_t * __restrict dst,
                                   int64_t * __restrict src,
                                   int                  size);
 
-void aligned_block_copy_nt_pf32_sse2(int64_t * __restrict dst,
+void aligned_block_copy_nt_pf32_avx2(int64_t * __restrict dst,
                                      int64_t * __restrict src,
                                      int                  size);
 void aligned_block_copy_nt_pf64_sse2(int64_t * __restrict dst,

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -37,7 +37,7 @@ void aligned_block_copy_movsd(int64_t * __restrict dst,
                               int64_t * __restrict src,
                               int                  size);
 
-void aligned_block_copy_sse2(int64_t * __restrict dst,
+void aligned_block_copy_avx2(int64_t * __restrict dst,
                              int64_t * __restrict src,
                              int                  size);
 void aligned_block_copy_nt_sse2(int64_t * __restrict dst,

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -30,13 +30,6 @@
 extern "C" {
 #endif
 
-void aligned_block_copy_movsb(int64_t * __restrict dst,
-                              int64_t * __restrict src,
-                              int                  size);
-void aligned_block_copy_movsd(int64_t * __restrict dst,
-                              int64_t * __restrict src,
-                              int                  size);
-
 void aligned_block_copy_avx2(int64_t * __restrict dst,
                              int64_t * __restrict src,
                              int                  size);

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -62,7 +62,7 @@ void aligned_block_fill_avx2(int64_t * __restrict dst,
                              int64_t * __restrict src,
                              int                  size);
 
-void aligned_block_fill_nt_sse2(int64_t * __restrict dst,
+void aligned_block_fill_nt_avx2(int64_t * __restrict dst,
                                 int64_t * __restrict src,
                                 int                  size);
 

--- a/x86-avx2.h
+++ b/x86-avx2.h
@@ -54,7 +54,7 @@ void aligned_block_copy_pf64_avx2(int64_t * __restrict dst,
 void aligned_block_copy_nt_pf32_avx2(int64_t * __restrict dst,
                                      int64_t * __restrict src,
                                      int                  size);
-void aligned_block_copy_nt_pf64_sse2(int64_t * __restrict dst,
+void aligned_block_copy_nt_pf64_avx2(int64_t * __restrict dst,
                                      int64_t * __restrict src,
                                      int                  size);
 

--- a/x86-avx512.S
+++ b/x86-avx512.S
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2020 Joel Luth <joelluth@gmail.com>
+ * Based on code by Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if defined(__amd64__)
+
+.intel_syntax noprefix
+.text
+
+#define PREFETCH_DISTANCE 256
+#define REGSZ 64
+
+.macro asm_function_helper function_name
+    .global \function_name
+.func \function_name
+\function_name:
+#ifdef _WIN64
+    .set DST,  rcx
+    .set SRC,  rdx
+    .set SIZE, r8
+#else
+    .set DST,  rdi
+    .set SRC,  rsi
+    .set SIZE, rdx
+#endif
+.endm
+
+.macro asm_function function_name
+asm_function_helper \function_name
+.endm
+
+.macro push3 a, b, c
+    push \a
+    push \b
+    push \c
+.endm
+
+.macro pop3 a, b, c
+    pop \c
+    pop \b
+    pop \a
+.endm
+
+/*****************************************************************************/
+
+asm_function aligned_block_copy_avx512
+0:
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], zmm0
+    vmovdqa      [DST + (1 * REGSZ)], zmm1
+    vmovdqa      [DST + (2 * REGSZ)], zmm2
+    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE, (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_avx512
+0:
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], zmm0
+    vmovntdq     [DST + (1 * REGSZ)], zmm1
+    vmovntdq     [DST + (2 * REGSZ)], zmm2
+    vmovntdq     [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE, (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_pf32_avx512
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], zmm0
+    vmovdqa      [DST + (1 * REGSZ)], zmm1
+    vmovdqa      [DST + (2 * REGSZ)], zmm2
+    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_pf32_avx512
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], zmm0
+    vmovntdq     [DST + (1 * REGSZ)], zmm1
+    vmovntdq     [DST + (2 * REGSZ)], zmm2
+    vmovntdq     [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_pf64_avx512
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa      [DST + (0 * REGSZ)], zmm0
+    vmovdqa      [DST + (1 * REGSZ)], zmm1
+    vmovdqa      [DST + (2 * REGSZ)], zmm2
+    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_copy_nt_pf64_avx512
+0:
+    prefetchnta [SRC + PREFETCH_DISTANCE]
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovntdq     [DST + (0 * REGSZ)], zmm0
+    vmovntdq     [DST + (1 * REGSZ)], zmm1
+    vmovntdq     [DST + (2 * REGSZ)], zmm2
+    vmovntdq     [DST + (3 * REGSZ)], zmm3
+    add         SRC,        (4 * REGSZ)
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_fill_avx512
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+0:
+    vmovdqa      [DST + (0 * REGSZ)], zmm0
+    vmovdqa      [DST + (1 * REGSZ)], zmm0
+    vmovdqa      [DST + (2 * REGSZ)], zmm0
+    vmovdqa      [DST + (3 * REGSZ)], zmm0
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+asm_function aligned_block_fill_nt_avx512
+    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+0:
+    vmovntdq     [DST + (0 * REGSZ)], zmm0
+    vmovntdq     [DST + (1 * REGSZ)], zmm0
+    vmovntdq     [DST + (2 * REGSZ)], zmm0
+    vmovntdq     [DST + (3 * REGSZ)], zmm0
+    add         DST,        (4 * REGSZ)
+    sub         SIZE,       (4 * REGSZ)
+    jg          0b
+    ret
+.endfunc
+
+/*****************************************************************************/
+
+#endif

--- a/x86-avx512.S
+++ b/x86-avx512.S
@@ -65,14 +65,14 @@ asm_function_helper \function_name
 
 asm_function aligned_block_copy_avx512
 0:
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
-    vmovdqa      [DST + (0 * REGSZ)], zmm0
-    vmovdqa      [DST + (1 * REGSZ)], zmm1
-    vmovdqa      [DST + (2 * REGSZ)], zmm2
-    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      [DST + (0 * REGSZ)], zmm0
+    vmovdqa64      [DST + (1 * REGSZ)], zmm1
+    vmovdqa64      [DST + (2 * REGSZ)], zmm2
+    vmovdqa64      [DST + (3 * REGSZ)], zmm3
     add         SRC,        (4 * REGSZ)
     add         DST,        (4 * REGSZ)
     sub         SIZE, (4 * REGSZ)
@@ -82,10 +82,10 @@ asm_function aligned_block_copy_avx512
 
 asm_function aligned_block_copy_nt_avx512
 0:
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
     vmovntdq     [DST + (0 * REGSZ)], zmm0
     vmovntdq     [DST + (1 * REGSZ)], zmm1
     vmovntdq     [DST + (2 * REGSZ)], zmm2
@@ -101,14 +101,14 @@ asm_function aligned_block_copy_pf32_avx512
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
     prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
-    vmovdqa      [DST + (0 * REGSZ)], zmm0
-    vmovdqa      [DST + (1 * REGSZ)], zmm1
-    vmovdqa      [DST + (2 * REGSZ)], zmm2
-    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      [DST + (0 * REGSZ)], zmm0
+    vmovdqa64      [DST + (1 * REGSZ)], zmm1
+    vmovdqa64      [DST + (2 * REGSZ)], zmm2
+    vmovdqa64      [DST + (3 * REGSZ)], zmm3
     add         SRC,        (4 * REGSZ)
     add         DST,        (4 * REGSZ)
     sub         SIZE,       (4 * REGSZ)
@@ -120,10 +120,10 @@ asm_function aligned_block_copy_nt_pf32_avx512
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
     prefetchnta [SRC + PREFETCH_DISTANCE + REGSZ]
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
     vmovntdq     [DST + (0 * REGSZ)], zmm0
     vmovntdq     [DST + (1 * REGSZ)], zmm1
     vmovntdq     [DST + (2 * REGSZ)], zmm2
@@ -138,14 +138,14 @@ asm_function aligned_block_copy_nt_pf32_avx512
 asm_function aligned_block_copy_pf64_avx512
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
-    vmovdqa      [DST + (0 * REGSZ)], zmm0
-    vmovdqa      [DST + (1 * REGSZ)], zmm1
-    vmovdqa      [DST + (2 * REGSZ)], zmm2
-    vmovdqa      [DST + (3 * REGSZ)], zmm3
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      [DST + (0 * REGSZ)], zmm0
+    vmovdqa64      [DST + (1 * REGSZ)], zmm1
+    vmovdqa64      [DST + (2 * REGSZ)], zmm2
+    vmovdqa64      [DST + (3 * REGSZ)], zmm3
     add         SRC,        (4 * REGSZ)
     add         DST,        (4 * REGSZ)
     sub         SIZE,       (4 * REGSZ)
@@ -156,10 +156,10 @@ asm_function aligned_block_copy_pf64_avx512
 asm_function aligned_block_copy_nt_pf64_avx512
 0:
     prefetchnta [SRC + PREFETCH_DISTANCE]
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
-    vmovdqa      zmm1,       [SRC + (1 * REGSZ)]
-    vmovdqa      zmm2,       [SRC + (2 * REGSZ)]
-    vmovdqa      zmm3,       [SRC + (3 * REGSZ)]
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm1,       [SRC + (1 * REGSZ)]
+    vmovdqa64      zmm2,       [SRC + (2 * REGSZ)]
+    vmovdqa64      zmm3,       [SRC + (3 * REGSZ)]
     vmovntdq     [DST + (0 * REGSZ)], zmm0
     vmovntdq     [DST + (1 * REGSZ)], zmm1
     vmovntdq     [DST + (2 * REGSZ)], zmm2
@@ -172,12 +172,12 @@ asm_function aligned_block_copy_nt_pf64_avx512
 .endfunc
 
 asm_function aligned_block_fill_avx512
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
 0:
-    vmovdqa      [DST + (0 * REGSZ)], zmm0
-    vmovdqa      [DST + (1 * REGSZ)], zmm0
-    vmovdqa      [DST + (2 * REGSZ)], zmm0
-    vmovdqa      [DST + (3 * REGSZ)], zmm0
+    vmovdqa64      [DST + (0 * REGSZ)], zmm0
+    vmovdqa64      [DST + (1 * REGSZ)], zmm0
+    vmovdqa64      [DST + (2 * REGSZ)], zmm0
+    vmovdqa64      [DST + (3 * REGSZ)], zmm0
     add         DST,        (4 * REGSZ)
     sub         SIZE,       (4 * REGSZ)
     jg          0b
@@ -185,7 +185,7 @@ asm_function aligned_block_fill_avx512
 .endfunc
 
 asm_function aligned_block_fill_nt_avx512
-    vmovdqa      zmm0,       [SRC + (0 * REGSZ)]
+    vmovdqa64      zmm0,       [SRC + (0 * REGSZ)]
 0:
     vmovntdq     [DST + (0 * REGSZ)], zmm0
     vmovntdq     [DST + (1 * REGSZ)], zmm0

--- a/x86-avx512.h
+++ b/x86-avx512.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2020 Joel Luth <joelluth@gmail.com>
+ * Based on code by Siarhei Siamashka <siarhei.siamashka@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __X86_AVX512_H__
+#define __X86_AVX512_H__
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void aligned_block_copy_avx512(int64_t * __restrict dst,
+                             int64_t * __restrict src,
+                             int                  size);
+void aligned_block_copy_nt_avx512(int64_t * __restrict dst,
+                                int64_t * __restrict src,
+                                int                  size);
+
+void aligned_block_copy_pf32_avx512(int64_t * __restrict dst,
+                                  int64_t * __restrict src,
+                                  int                  size);
+void aligned_block_copy_pf64_avx512(int64_t * __restrict dst,
+                                  int64_t * __restrict src,
+                                  int                  size);
+
+void aligned_block_copy_nt_pf32_avx512(int64_t * __restrict dst,
+                                     int64_t * __restrict src,
+                                     int                  size);
+void aligned_block_copy_nt_pf64_avx512(int64_t * __restrict dst,
+                                     int64_t * __restrict src,
+                                     int                  size);
+
+void aligned_block_fill_avx512(int64_t * __restrict dst,
+                             int64_t * __restrict src,
+                             int                  size);
+
+void aligned_block_fill_nt_avx512(int64_t * __restrict dst,
+                                int64_t * __restrict src,
+                                int                  size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Add AVX2 and AVX512 benchmarks, based on the existing SSE2 benchmarks.
Add runtime arguments (--run_*) to execute some/all of the SSE/AVX benchmarks.